### PR TITLE
Remove latexsym dependency

### DIFF
--- a/gnuplottex.dtx
+++ b/gnuplottex.dtx
@@ -43,7 +43,7 @@
 %<package> \ProvidesPackage{gnuplottex}
 %<*package>
     [2013/11/24 v0.8 gnuplot graphs in LaTeX]
-\RequirePackage{latexsym,graphicx,moreverb,keyval,ifthen}
+\RequirePackage{graphicx,moreverb,keyval,ifthen}
 %</package>
 %
 %<*driver>


### PR DESCRIPTION
Caused an error due to too much alphabets in use.
What was the purpose of it, anyway?
Short (and certainly not comprehensive) testing revealed no problems.
